### PR TITLE
Change : to / for scp-style remote URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ When collaborating with your team, you may often want to reference a line of cod
 ![screenshot](https://raw.githubusercontent.com/mazubieta/gitlink-vim/master/docs/inbrowser.png)
 
 ##Known Issues
-It currently only supports repositories with remotes using ```https```, not those that use```ssh```.
+
 As written, it only works for Github and Gitlab.  Bitbucket is not supported.
 
 ##Installation

--- a/autoload/gitlink.vim
+++ b/autoload/gitlink.vim
@@ -26,7 +26,8 @@ function! gitlink#GitLink()
         if match(l:remote, '^https://') != -1
             let l:repoURL = l:remote
         elseif match(l:remote, '^git@') != -1
-            let l:repoURL = substitute(l:remote,"^git@","https://","")
+            let l:repoURL = substitute(l:remote,":","/","")
+            let l:repoURL = substitute(l:repoURL,"^git@","https://","")
         elseif match(l:remote, '^ssh://') != -1
             let l:repoURL = substitute(l:remote,"^ssh://","https://","")
         elseif match(l:remote, '^git:') != -1


### PR DESCRIPTION
For example:

```
git@github.com:DuBistKomisch/gitlink-vim.git
```

It would previously produce a URL like:

https://github.com:DuBistKomisch/gitlink-vim/tree/b0eabbe6c66d469ee0f6793208728cf19beb10b3/autoload/gitlink.vim#L29 (broken)

This PR changes it to:

https://github.com/DuBistKomisch/gitlink-vim/tree/b0eabbe6c66d469ee0f6793208728cf19beb10b3/autoload/gitlink.vim#L29 (works)

P.S. this plugin is super useful, wish I found it earlier