### PR TITLE
Implement range links

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,25 +29,44 @@ You can add the following lines to your ```.vimrc``` file.
 
 - If you want to execute via command:
 
-    ```command GitLink :echo gitlink#GitLink()```
+  ```
+  command GitLink :echo gitlink#GitLink()
+  ```
 
-- If you want to execute via leader command
+- If you want to execute via leader command:
 
-    ```nmap <leader>gl :echo gitlink#GitLink()<CR>```
+  ```
+  nmap <leader>gl :echo gitlink#GitLink()<CR>
+  vmap <leader>gl :echo gitlink#GitLink(1)<CR>
+  ```
+
+- If you want to copy to the clipboard automatically:
+
+  ```
+  function! CopyGitLink(...) range
+    redir @+
+    silent echo gitlink#GitLink(get(a:, 1, 0))
+    redir END
+  endfunction
+  nmap <leader>gl :call CopyGitLink()<CR>
+  vmap <leader>gl :call CopyGitLink(1)<CR>
+  ```
 
 ## Usage
 - If you just autoload the script
 
-    ```:echo #gitlink#GitLink()``` 
+  ```
+  :echo gitlink#GitLink()
+  ```
 
 - If you added the optional .vimrc lines
 
-```
-:GitLink
-```
+  ```
+  :GitLink
+  ```
 
-Or ...
+  Or...
 
-```
-\gl
-```
+  ```
+  \gl
+  ```

--- a/autoload/gitlink.vim
+++ b/autoload/gitlink.vim
@@ -7,10 +7,10 @@
 " License: MIT                                                               =
 "=============================================================================
 
-function! gitlink#GitLink()
+function! gitlink#GitLink(...)
     let l:hash = substitute(system("git rev-parse HEAD 2>/dev/null"),"\n","","")
     if l:hash != ''
-        let l:line = line('.')
+        let l:line = get(a:, 1, 0) ? line("'<") . "-L" . line("'>") : line(".")
         let l:path = expand("%:p")
         let l:diff = strlen(system("git diff " . l:path))
         if l:diff


### PR DESCRIPTION
Addresses https://github.com/mazubieta/gitlink-vim/issues/5.

Turns out it's pretty awkward to use the built in ranges with functions since they only work with `call`, and I couldn't find a way to put it conveniently in a command or mapping without requiring lots of wrapping functions.

This solution just reads the lines of the range markers, but unfortunately you have to explicitly provide whether you were in visual mode because you're actually always in command editing mode when calling a function (see `:help mode`). You might be able to get around this with `<expr>` mappings, but it's probably even more code for no real reason.

Also added more details to usage such as copying to clipboard automatically.